### PR TITLE
Tidy blochmessiah decomp

### DIFF
--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -130,14 +130,11 @@ def blochmessiah(S):
                array[float])  : orthogonal symplectic matrix vff
     """
 
-    N, m = S.shape
+    N, _ = S.shape
 
-    if N != m:
-        return False
-    if N % 2 != 0:
-        return False
     if not is_symplectic(S):
-        return False
+        raise ValueError("Input matrix is not symplectic.")
+
     # Changing Basis
     R = (1 / np.sqrt(2)) * np.block(
         [[np.eye(N // 2), 1j * np.eye(N // 2)], [np.eye(N // 2), -1j * np.eye(N // 2)]]

--- a/thewalrus/tests/test_decompositions.py
+++ b/thewalrus/tests/test_decompositions.py
@@ -152,7 +152,46 @@ class TestWilliamsonDecomposition:
 
 
 class TestBlochMessiahDecomposition:
-    """Tests for the Williamson decomposition"""
+    """Tests for the Bloch Messiah decomposition"""
+
+    @pytest.fixture
+    def create_transform(self):
+        """create a symplectic transform for use in testing.
+
+        Args:
+            n (int): number of modes
+            passive (bool): whether transform should be passive or not
+
+        Returns:
+            array: symplectic matrix
+        """
+
+        def _create_transform(n, passive=True):
+            """wrapped function"""
+            O = omega(n)
+
+            # interferometer 1
+            U1 = haar_measure(n)
+            S1 = np.vstack([np.hstack([U1.real, -U1.imag]), np.hstack([U1.imag, U1.real])])
+
+            Sq = np.identity(2 * n)
+            if not passive:
+                # squeezing
+                r = np.log(0.2 * np.arange(n) + 2)
+                Sq = block_diag(np.diag(np.exp(-r)), np.diag(np.exp(r)))
+
+            # interferometer 2
+            U2 = haar_measure(n)
+            S2 = np.vstack([np.hstack([U2.real, -U2.imag]), np.hstack([U2.imag, U2.real])])
+
+            # final symplectic
+            S_final = S2 @ Sq @ S1
+
+            # check valid symplectic transform
+            assert np.allclose(S_final.T @ O @ S_final, O)
+            return S_final
+
+        return _create_transform
 
     @pytest.mark.parametrize("N", range(50, 500, 50))
     def test_blochmessiah_rand(self, N):
@@ -160,22 +199,57 @@ class TestBlochMessiahDecomposition:
         S = random_symplectic(N)
         u, d, v = blochmessiah(S)
         assert np.allclose(u @ d @ v, S)
-        np.allclose(u.T @ u, np.eye(len(u)))
-        np.allclose(v.T @ v, np.eye(len(v)))
-        is_symplectic(u)
-        is_symplectic(v)
+        assert np.allclose(u.T @ u, np.eye(len(u)))
+        assert np.allclose(v.T @ v, np.eye(len(v)))
+        assert is_symplectic(u)
+        assert is_symplectic(v)
 
-    def test_blochmessiah_odd(self):
-        """Tests that odd matrices return False in blochmessiah."""
-        S = np.random.rand(5, 5)
-        assert not blochmessiah(S)
+    @pytest.mark.parametrize("M", [np.random.rand(4, 5), np.random.rand(4, 4)])
+    def test_blochmessiah_error(self, M):
+        """Tests that non-symplectic matrices raise a ValueError in blochmessiah."""
+        with pytest.raises(ValueError, match="Input matrix is not symplectic."):
+            blochmessiah(M)
 
-    def test_blochmessiah_rect(self):
-        """Tests that rectangular matrices return False in blochmessiah"""
-        S = np.random.rand(4, 5)
-        assert not blochmessiah(S)
+    def test_identity(self, tol):
+        """Test identity"""
+        n = 2
+        S_in = np.identity(2 * n)
+        O1, S, O2 = blochmessiah(S_in)
 
-    def test_blochmessiah_false(self):
-        """Tests that non-symplectic mattrices return False in blochmessiah"""
-        S = np.random.rand(4, 4)
-        assert not blochmessiah(S)
+        assert np.allclose(O1 @ O2, np.identity(2 * n), atol=tol, rtol=0)
+        assert np.allclose(S, np.identity(2 * n), atol=tol, rtol=0)
+
+        # test orthogonality
+        assert np.allclose(O1.T, O1, atol=tol, rtol=0)
+        assert np.allclose(O2.T, O2, atol=tol, rtol=0)
+
+        # test symplectic
+        O = omega(n)
+        assert np.allclose(O1 @ O @ O1.T, O, atol=tol, rtol=0)
+        assert np.allclose(O2 @ O @ O2.T, O, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("passive", [True, False])
+    def test_transform(self, passive, create_transform, tol):
+        """Test decomposition agrees with transform. also checks that passive transform has no squeezing.
+        Note: this test also tests the case with degenerate symplectic values"""
+        n = 3
+        S_in = create_transform(3, passive=passive)
+        O1, S, O2 = blochmessiah(S_in)
+
+        # test decomposition
+        assert np.allclose(O1 @ S @ O2, S_in, atol=tol, rtol=0)
+
+        # test no squeezing
+        if passive:
+            assert np.allclose(O1 @ O2, S_in, atol=tol, rtol=0)
+            assert np.allclose(S, np.identity(2 * n), atol=tol, rtol=0)
+
+        # test orthogonality
+        assert np.allclose(O1.T @ O1, np.identity(2 * n), atol=tol, rtol=0)
+        assert np.allclose(O2.T @ O2, np.identity(2 * n), atol=tol, rtol=0)
+
+        # test symplectic
+        O = omega(n)
+        assert np.allclose(O1.T @ O @ O1, O, atol=tol, rtol=0)
+        assert np.allclose(O2.T @ O @ O2, O, atol=tol, rtol=0)
+        assert np.allclose(S @ O @ S.T, O, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**
Improved Bloch-Messiah that gives correct results when the symplectic matrix is degenerate has been added to this The Walrus fork

**Description of the Change:**
This PR adds unit testing (from strawberryfields) and error handling in order to use this implementation in strawberryfields.

**Benefits:**
Extended unit testing and error handling.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
https://github.com/XanaduAI/strawberryfields/issues/728